### PR TITLE
Add support for transactional save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.3
+
+- Add support for transaction bundle in the create request.
+
 ## 0.0.2
 
 - Add support for additional path parameters in request.

--- a/lib/src/fhir_rest_client.dart
+++ b/lib/src/fhir_rest_client.dart
@@ -61,7 +61,7 @@ class FhirRestClient {
     // such as $reindex, $export or similar (these operations usually have
     // different resourceType as parameter)
     final parameters = Map.from(request.parameters);
-    if (!request.entityName.startsWith('\$')) {
+    if (!request.entityName.startsWith('\$') && request.entityName.isNotEmpty) {
       parameters["resourceType"] = request.entityName;
     }
 
@@ -79,6 +79,7 @@ class FhirRestClient {
 
     switch (response.statusCode) {
       // request was ok
+      case 200:
       case 201:
         return response.data as Map<String, dynamic>;
       // backend validation failed

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: fhir_rest_client
 description: A Dart package to describe FHIR REST calls and corresponding client
   to send these requests to a FHIR server
-version: 0.0.2
+version: 0.0.3
 homepage: https://www.evoleen.com
 repository: https://github.com/evoleen/fhir_rest_client
 


### PR DESCRIPTION
Fhir rest client should support transactional save to FHIR DB (instead of saving entities in for loops with awaits inside each iteration performing single save)

It is done by executing base fhir url endpoint using Bundle object with specific structure: https://build.fhir.org/bundle-transaction.json.html

This PR allows executing base fhir URL (leaving empty entityName: performed change results in not getting overriden by Bundle entity name and executing /Bundle endpoint). Transaction bundle returns 200 code.
