### PR TITLE
chore: update fhir_r4 to 0.5.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 # Add regular dependencies here.
 dependencies:
   dio: ^5.9.0
-  fhir_r4: ^0.4.2
+  fhir_r4: ^0.5.1
   freezed_annotation: ^3.1.0
   json_annotation: ^4.9.0
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Dependency-only upgrade, but `fhir_r4` is a core library and a minor-version bump may introduce breaking API/serialization changes that could surface at compile time or in FHIR parsing/encoding.
> 
> **Overview**
> Updates the `fhir_r4` dependency constraint in `pubspec.yaml` from `^0.4.2` to `^0.5.1`, pulling in the newer FHIR R4 model/library version with no accompanying code changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e067cece540761cbdeaa5d5eb943a3e5b002190. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->